### PR TITLE
Feature/add logging

### DIFF
--- a/src/features/hello.js
+++ b/src/features/hello.js
@@ -9,11 +9,10 @@ module.exports = async (controller) => {
           const response =
             "Yo! Ask me what's on & then go check out some killer music.";
 
-          message.response = response;
-
           await bot.reply(message, response);
 
           // console.log(`Full Log: ${JSON.stringify(message)}`);
+          message.response = response;
           const log = await logConversation(message);
           console.log(log);
         }

--- a/src/features/hello.js
+++ b/src/features/hello.js
@@ -11,11 +11,11 @@ module.exports = async (controller) => {
 
           message.response = response;
 
+          await bot.reply(message, response);
+
           // console.log(`Full Log: ${JSON.stringify(message)}`);
           const log = await logConversation(message);
           console.log(log);
-
-          await bot.reply(message, response);
         }
       } catch (e) {
         console.log(e);

--- a/src/features/hello.js
+++ b/src/features/hello.js
@@ -7,6 +7,10 @@ module.exports = async (controller) => {
           const response =
             "Yo! Ask me what's on & then go check out some killer music.";
 
+          message.response = response;
+
+          console.log(`Full Log: ${JSON.stringify(message)}`);
+
           await bot.reply(message, response);
         }
       } catch (e) {

--- a/src/features/hello.js
+++ b/src/features/hello.js
@@ -11,10 +11,10 @@ module.exports = async (controller) => {
 
           message.response = response;
 
-          await logConversation(message);
           // console.log(`Full Log: ${JSON.stringify(message)}`);
 
           await bot.reply(message, response);
+          logConversation(message);
         }
       } catch (e) {
         console.log(e);

--- a/src/features/hello.js
+++ b/src/features/hello.js
@@ -12,9 +12,10 @@ module.exports = async (controller) => {
           message.response = response;
 
           // console.log(`Full Log: ${JSON.stringify(message)}`);
+          const log = await logConversation(message);
+          console.log(log);
 
           await bot.reply(message, response);
-          logConversation(message);
         }
       } catch (e) {
         console.log(e);

--- a/src/features/hello.js
+++ b/src/features/hello.js
@@ -1,3 +1,5 @@
+const logConversation = require('../utils/logger');
+
 module.exports = async (controller) => {
   controller.on(
     'message,direct_message,facebook_postback',
@@ -9,7 +11,8 @@ module.exports = async (controller) => {
 
           message.response = response;
 
-          console.log(`Full Log: ${JSON.stringify(message)}`);
+          logConversation(message);
+          // console.log(`Full Log: ${JSON.stringify(message)}`);
 
           await bot.reply(message, response);
         }

--- a/src/features/hello.js
+++ b/src/features/hello.js
@@ -1,4 +1,5 @@
-const logConversation = require('../utils/logger');
+const { MongoClient } = require('mongodb');
+// const logConversation = require('../utils/logger');
 
 module.exports = async (controller) => {
   controller.on(
@@ -11,8 +12,20 @@ module.exports = async (controller) => {
 
           message.response = response;
 
-          logConversation(message);
+          // logConversation(message);
           // console.log(`Full Log: ${JSON.stringify(message)}`);
+          const client = new MongoClient(process.env.MONGO_URI, {
+            useUnifiedTopology: true,
+          });
+
+          await client.connect();
+
+          const db = client.db('zootdb');
+          const logs = db.collection('logs');
+
+          const result = await logs.insertOne(message);
+
+          console.log(result);
 
           await bot.reply(message, response);
         }

--- a/src/features/hello.js
+++ b/src/features/hello.js
@@ -1,5 +1,4 @@
-const { MongoClient } = require('mongodb');
-// const logConversation = require('../utils/logger');
+const logConversation = require('../utils/logger');
 
 module.exports = async (controller) => {
   controller.on(
@@ -12,20 +11,8 @@ module.exports = async (controller) => {
 
           message.response = response;
 
-          // logConversation(message);
+          logConversation(message);
           // console.log(`Full Log: ${JSON.stringify(message)}`);
-          const client = new MongoClient(process.env.MONGO_URI, {
-            useUnifiedTopology: true,
-          });
-
-          await client.connect();
-
-          const db = client.db('zootdb');
-          const logs = db.collection('logs');
-
-          const result = await logs.insertOne(message);
-
-          console.log(result);
 
           await bot.reply(message, response);
         }

--- a/src/features/hello.js
+++ b/src/features/hello.js
@@ -11,7 +11,6 @@ module.exports = async (controller) => {
 
           await bot.reply(message, response);
 
-          // console.log(`Full Log: ${JSON.stringify(message)}`);
           message.response = response;
           const log = await logConversation(message);
           console.log(log);

--- a/src/features/hello.js
+++ b/src/features/hello.js
@@ -11,7 +11,7 @@ module.exports = async (controller) => {
 
           message.response = response;
 
-          logConversation(message);
+          await logConversation(message);
           // console.log(`Full Log: ${JSON.stringify(message)}`);
 
           await bot.reply(message, response);

--- a/src/features/help.js
+++ b/src/features/help.js
@@ -1,3 +1,5 @@
+const logConversation = require('../utils/logger');
+
 module.exports = async (controller) => {
   controller.on(
     'message,direct_message,facebook_postback',
@@ -9,6 +11,10 @@ module.exports = async (controller) => {
         https://github.com/zootytooty/BeBot`;
 
           await bot.reply(message, response);
+
+          message.response = response;
+          const log = await logConversation(message);
+          console.log(log);
         }
       } catch (e) {
         console.log(e);

--- a/src/features/list_venues.js
+++ b/src/features/list_venues.js
@@ -8,8 +8,6 @@ module.exports = async (controller) => {
         if (message.intents[0].name === 'venues') {
           const response = await getVenues();
 
-          console.log(response);
-
           if (typeof response === 'object') {
             await bot.reply(message, {
               attachment: response,

--- a/src/features/list_venues.js
+++ b/src/features/list_venues.js
@@ -1,4 +1,5 @@
 const getVenues = require('../utils/get_venues');
+const logConversation = require('../utils/logger');
 
 module.exports = async (controller) => {
   controller.on(
@@ -12,8 +13,16 @@ module.exports = async (controller) => {
             await bot.reply(message, {
               attachment: response,
             });
+
+            message.response = response;
+            const log = await logConversation(message);
+            console.log(log);
           } else {
             await bot.reply(message, response);
+
+            message.response = response;
+            const log = await logConversation(message);
+            console.log(log);
           }
         }
       } catch (e) {

--- a/src/features/whats_on.js
+++ b/src/features/whats_on.js
@@ -1,5 +1,6 @@
 const queryBuilder = require('../utils/query_builder');
 const getGigs = require('../utils/get_gigs');
+const logConversation = require('../utils/logger');
 
 module.exports = async (controller) => {
   controller.on(
@@ -13,8 +14,16 @@ module.exports = async (controller) => {
             await bot.reply(message, {
               attachment: response,
             });
+
+            message.response = response;
+            const log = await logConversation(message);
+            console.log(log);
           } else {
             await bot.reply(message, response);
+
+            message.response = response;
+            const log = await logConversation(message);
+            console.log(log);
           }
         }
       } catch (e) {

--- a/src/features/whats_on.js
+++ b/src/features/whats_on.js
@@ -9,8 +9,6 @@ module.exports = async (controller) => {
         if (message.intents[0].name === 'whats_on') {
           const response = await getGigs(queryBuilder(message));
 
-          console.log(response);
-
           if (typeof response === 'object') {
             await bot.reply(message, {
               attachment: response,

--- a/src/middleware/wit-ai.js
+++ b/src/middleware/wit-ai.js
@@ -32,11 +32,10 @@ module.exports = ({ accessToken, logLevel = DEFAULT_LOG_LEVEL } = {}) => {
       try {
         const witData = await client.message(message.text);
 
-        console.log(`Wit.ai response: ${JSON.stringify(witData)}`);
-
         message.intents = witData.intents;
         message.entities = witData.entities;
         message.traits = witData.traits;
+        message.wit = witData;
         next();
       } catch (e) {
         console.log(e);

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -5,7 +5,8 @@ const { MongoClient } = require('mongodb');
 // It's deleting important info from the reference object
 // This should be a trival fix for anyone a little less spaz than me
 function cleanMessage(message) {
-  const conversation = { ...message };
+  //   const conversation = { ...message };
+  const conversation = JSON.parse(JSON.stringify(message));
   // Clean up the Wit attributes
   if (Object.prototype.hasOwnProperty.call(conversation, 'entities')) {
     delete conversation.entities;

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -37,10 +37,11 @@ const logConversation = async (message) => {
     const db = client.db('zootdb');
     const logs = db.collection('logs');
 
-    const result = await logs.insertOne({
-      name: 'Company Inc',
-      address: 'Highway 37',
-    });
+    const result = await logs.insertOne(cleanedMessage);
+    // const result = await logs.insertOne({
+    //   name: 'Company Inc',
+    //   address: 'Highway 37',
+    // });
     console.log(JSON.stringify(cleanedMessage));
     return result;
   } catch (ex) {

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,24 +1,25 @@
-const { MongoClient } = require('mongodb');
+// const { MongoClient } = require('mongodb');
 
 const logConversation = async (conversation) => {
-  const client = new MongoClient(process.env.MONGO_URI, {
-    useUnifiedTopology: true,
-  });
-  try {
-    await client.connect();
+  //   const client = new MongoClient(process.env.MONGO_URI, {
+  //     useUnifiedTopology: true,
+  //   });
+  //   try {
+  //     await client.connect();
 
-    const db = client.db('zootdb');
-    const logs = db.collection('logs');
+  //     const db = client.db('zootdb');
+  //     const logs = db.collection('logs');
 
-    const result = await logs.insertOne(conversation);
+  //     const result = await logs.insertOne(conversation);
 
-    return result;
-  } catch (ex) {
-    console.log(ex);
-    return ex;
-  } finally {
-    await client.close();
-  }
+  //     return result;
+  //   } catch (ex) {
+  //     console.log(ex);
+  //     return ex;
+  //   } finally {
+  //     await client.close();
+  //   }
+  console.log(conversation);
 };
 
 module.exports = logConversation;

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,7 +1,8 @@
 /* eslint-disable no-underscore-dangle */
 const { MongoClient } = require('mongodb');
 
-const logConversation = async (conversation) => {
+const logConversation = async (message) => {
+  const conversation = message;
   // Clean up the Wit attributes
   if (Object.prototype.hasOwnProperty.call(conversation, 'entities')) {
     delete conversation.entities;

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -4,6 +4,18 @@ const logConversation = async (conversation) => {
   const client = new MongoClient(process.env.MONGO_URI, {
     useUnifiedTopology: true,
   });
+
+  client.connect((err, db) => {
+    if (err) throw err;
+    const dbo = db.db('zootdb');
+
+    dbo.collection('logs').insertOne(conversation, (error, res) => {
+      if (error) throw error;
+      console.log(res);
+      db.close();
+    });
+  });
+
   // try {
   //   await client.connect();
 
@@ -19,7 +31,7 @@ const logConversation = async (conversation) => {
   // } finally {
   //   await client.close();
   // }
-  console.log(client, conversation);
+  //   console.log(client, conversation);
 };
 
 module.exports = logConversation;

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -4,29 +4,29 @@ const { MongoClient } = require('mongodb');
 // This doesn't work as expected & breaks the bot
 // It's deleting important info from the reference object
 // This should be a trival fix for anyone a little less spaz than me
-// function clean_message(message) {
-//   const conversation = message;
-//   // Clean up the Wit attributes
-//   if (Object.prototype.hasOwnProperty.call(conversation, 'entities')) {
-//     delete conversation.entities;
-//   }
-//   if (Object.prototype.hasOwnProperty.call(conversation, 'traits')) {
-//     delete conversation.traits;
-//   }
-//   if (Object.prototype.hasOwnProperty.call(conversation, 'intents')) {
-//     delete conversation.intents;
-//   }
+function cleanMessage(message) {
+  const conversation = { ...message };
+  // Clean up the Wit attributes
+  if (Object.prototype.hasOwnProperty.call(conversation, 'entities')) {
+    delete conversation.entities;
+  }
+  if (Object.prototype.hasOwnProperty.call(conversation, 'traits')) {
+    delete conversation.traits;
+  }
+  if (Object.prototype.hasOwnProperty.call(conversation, 'intents')) {
+    delete conversation.intents;
+  }
 
-//   // Facebook sends everything including keys. We don't want to store them
-//   delete conversation.context._adapter.options.access_token;
-//   delete conversation.context._adapter.options.verify_token;
-//   delete conversation.context._adapter.options.app_secret;
+  // Facebook sends everything including keys. We don't want to store them
+  delete conversation.context._adapter.options.access_token;
+  delete conversation.context._adapter.options.verify_token;
+  delete conversation.context._adapter.options.app_secret;
 
-//   return conversation;
-// }
+  return conversation;
+}
 
 const logConversation = async (message) => {
-  // const cleaned_message = clean_message(message);
+  const cleanedMessage = cleanMessage(message);
   const client = new MongoClient(process.env.MONGO_URI, {
     useUnifiedTopology: true,
   });
@@ -41,7 +41,7 @@ const logConversation = async (message) => {
       name: 'Company Inc',
       address: 'Highway 37',
     });
-    console.log(message);
+    console.log(JSON.stringify(cleanedMessage));
     return result;
   } catch (ex) {
     console.log(ex);

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,11 +1,7 @@
 /* eslint-disable no-underscore-dangle */
 const { MongoClient } = require('mongodb');
 
-// This doesn't work as expected & breaks the bot
-// It's deleting important info from the reference object
-// This should be a trival fix for anyone a little less spaz than me
 function cleanMessage(message) {
-  //   const conversation = { ...message };
   const conversation = JSON.parse(JSON.stringify(message));
   // Clean up the Wit attributes
   if (Object.prototype.hasOwnProperty.call(conversation, 'entities')) {
@@ -39,11 +35,6 @@ const logConversation = async (message) => {
     const logs = db.collection('logs');
 
     const result = await logs.insertOne(cleanedMessage);
-    // const result = await logs.insertOne({
-    //   name: 'Company Inc',
-    //   address: 'Highway 37',
-    // });
-    console.log(JSON.stringify(cleanedMessage));
     return result;
   } catch (ex) {
     console.log(ex);

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -37,7 +37,11 @@ const logConversation = async (message) => {
     const db = client.db('zootdb');
     const logs = db.collection('logs');
 
-    const result = await logs.insertOne(message);
+    const result = await logs.insertOne({
+      name: 'Company Inc',
+      address: 'Highway 37',
+    });
+    console.log(message);
     return result;
   } catch (ex) {
     console.log(ex);

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,0 +1,23 @@
+const { MongoClient } = require('mongodb');
+
+async function logConversation(conversation) {
+  const client = new MongoClient(process.env.MONGO_URI, {
+    useUnifiedTopology: true,
+  });
+  try {
+    await client.connect();
+
+    const db = client.db('zootdb');
+    const logs = db.collection('logs');
+
+    const result = await logs.insertOne(conversation);
+
+    console.log(result);
+  } catch (ex) {
+    console.log(ex);
+  } finally {
+    await client.close();
+  }
+}
+
+module.exports = logConversation;

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,6 +1,9 @@
 /* eslint-disable no-underscore-dangle */
 const { MongoClient } = require('mongodb');
 
+// This doesn't work as expected & breaks the bot
+// It's deleting important info from the reference object
+// This should be a trival fix for anyone a little less spaz than me
 // function clean_message(message) {
 //   const conversation = message;
 //   // Clean up the Wit attributes
@@ -31,9 +34,9 @@ const logConversation = async (message) => {
   try {
     await client.connect();
 
+    const db = client.db('zootdb');
     console.log(message);
-    return client;
-    //   const db = client.db('zootdb');
+    return db;
     //   const logs = db.collection('logs');
 
     // //   const result = await logs.insertOne(conversation);

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,25 +1,25 @@
-// const { MongoClient } = require('mongodb');
+const { MongoClient } = require('mongodb');
 
 const logConversation = async (conversation) => {
-  //   const client = new MongoClient(process.env.MONGO_URI, {
-  //     useUnifiedTopology: true,
-  //   });
-  //   try {
-  //     await client.connect();
+  const client = new MongoClient(process.env.MONGO_URI, {
+    useUnifiedTopology: true,
+  });
+  // try {
+  //   await client.connect();
 
-  //     const db = client.db('zootdb');
-  //     const logs = db.collection('logs');
+  //   const db = client.db('zootdb');
+  //   const logs = db.collection('logs');
 
-  //     const result = await logs.insertOne(conversation);
+  // //   const result = await logs.insertOne(conversation);
 
-  //     return result;
-  //   } catch (ex) {
-  //     console.log(ex);
-  //     return ex;
-  //   } finally {
-  //     await client.close();
-  //   }
-  console.log(conversation);
+  //   return result;
+  // } catch (ex) {
+  //   console.log(ex);
+  //   return ex;
+  // } finally {
+  //   await client.close();
+  // }
+  console.log(client, conversation);
 };
 
 module.exports = logConversation;

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,24 +1,29 @@
 /* eslint-disable no-underscore-dangle */
 const { MongoClient } = require('mongodb');
 
+// function clean_message(message) {
+//   const conversation = message;
+//   // Clean up the Wit attributes
+//   if (Object.prototype.hasOwnProperty.call(conversation, 'entities')) {
+//     delete conversation.entities;
+//   }
+//   if (Object.prototype.hasOwnProperty.call(conversation, 'traits')) {
+//     delete conversation.traits;
+//   }
+//   if (Object.prototype.hasOwnProperty.call(conversation, 'intents')) {
+//     delete conversation.intents;
+//   }
+
+//   // Facebook sends everything including keys. We don't want to store them
+//   delete conversation.context._adapter.options.access_token;
+//   delete conversation.context._adapter.options.verify_token;
+//   delete conversation.context._adapter.options.app_secret;
+
+//   return conversation;
+// }
+
 const logConversation = async (message) => {
-  const conversation = message;
-  // Clean up the Wit attributes
-  if (Object.prototype.hasOwnProperty.call(conversation, 'entities')) {
-    delete conversation.entities;
-  }
-  if (Object.prototype.hasOwnProperty.call(conversation, 'traits')) {
-    delete conversation.traits;
-  }
-  if (Object.prototype.hasOwnProperty.call(conversation, 'intents')) {
-    delete conversation.intents;
-  }
-
-  // Facebook sends everything including keys. We don't want to store them
-  delete conversation.context._adapter.options.access_token;
-  delete conversation.context._adapter.options.verify_token;
-  delete conversation.context._adapter.options.app_secret;
-
+  // const cleaned_message = clean_message(message);
   const client = new MongoClient(process.env.MONGO_URI, {
     useUnifiedTopology: true,
   });
@@ -26,6 +31,7 @@ const logConversation = async (message) => {
   try {
     await client.connect();
 
+    console.log(message);
     return client;
     //   const db = client.db('zootdb');
     //   const logs = db.collection('logs');
@@ -39,7 +45,6 @@ const logConversation = async (message) => {
   } finally {
     await client.close();
   }
-  //   console.log(client, conversation);
 };
 
 module.exports = logConversation;

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,36 +1,43 @@
+/* eslint-disable no-underscore-dangle */
 const { MongoClient } = require('mongodb');
 
 const logConversation = async (conversation) => {
+  // Clean up the Wit attributes
+  if (Object.prototype.hasOwnProperty.call(conversation, 'entities')) {
+    delete conversation.entities;
+  }
+  if (Object.prototype.hasOwnProperty.call(conversation, 'traits')) {
+    delete conversation.traits;
+  }
+  if (Object.prototype.hasOwnProperty.call(conversation, 'intents')) {
+    delete conversation.intents;
+  }
+
+  // Facebook sends everything including keys. We don't want to store them
+  delete conversation.context._adapter.options.access_token;
+  delete conversation.context._adapter.options.verify_token;
+  delete conversation.context._adapter.options.app_secret;
+
   const client = new MongoClient(process.env.MONGO_URI, {
     useUnifiedTopology: true,
   });
 
-  client.connect((err, db) => {
-    if (err) throw err;
-    const dbo = db.db('zootdb');
+  try {
+    await client.connect();
 
-    dbo.collection('logs').insertOne(conversation, (error, res) => {
-      if (error) throw error;
-      console.log(res);
-      db.close();
-    });
-  });
+    return client;
+    //   const db = client.db('zootdb');
+    //   const logs = db.collection('logs');
 
-  // try {
-  //   await client.connect();
+    // //   const result = await logs.insertOne(conversation);
 
-  //   const db = client.db('zootdb');
-  //   const logs = db.collection('logs');
-
-  // //   const result = await logs.insertOne(conversation);
-
-  //   return result;
-  // } catch (ex) {
-  //   console.log(ex);
-  //   return ex;
-  // } finally {
-  //   await client.close();
-  // }
+    //   return result;
+  } catch (ex) {
+    console.log(ex);
+    return ex;
+  } finally {
+    await client.close();
+  }
   //   console.log(client, conversation);
 };
 

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -36,12 +36,9 @@ const logConversation = async (message) => {
 
     const db = client.db('zootdb');
     const logs = db.collection('logs');
-    console.log(message);
-    return logs;
 
-    // //   const result = await logs.insertOne(conversation);
-
-    //   return result;
+    const result = await logs.insertOne(message);
+    return result;
   } catch (ex) {
     console.log(ex);
     return ex;

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,6 +1,6 @@
 const { MongoClient } = require('mongodb');
 
-async function logConversation(conversation) {
+const logConversation = async (conversation) => {
   const client = new MongoClient(process.env.MONGO_URI, {
     useUnifiedTopology: true,
   });
@@ -12,12 +12,13 @@ async function logConversation(conversation) {
 
     const result = await logs.insertOne(conversation);
 
-    console.log(result);
+    return result;
   } catch (ex) {
     console.log(ex);
+    return ex;
   } finally {
     await client.close();
   }
-}
+};
 
 module.exports = logConversation;

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -35,9 +35,9 @@ const logConversation = async (message) => {
     await client.connect();
 
     const db = client.db('zootdb');
+    const logs = db.collection('logs');
     console.log(message);
-    return db;
-    //   const logs = db.collection('logs');
+    return logs;
 
     // //   const result = await logs.insertOne(conversation);
 


### PR DESCRIPTION
Closes #11 

For every message this logs to `zootdb.logs` the:
- Full request message from facebook & whatever the botkit controller contains
- The full Wit response
- The message we return

The function has been applied to all routes.

A unique user ID appears to be present from FB so we could in theory start to generate some basic analytics such as number of unique users, their activity rates, etc